### PR TITLE
Ensure DreamDaemon exists before checking version

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,11 +1,17 @@
 ---
+- name: Check if BYOND is installed
+  stat:
+    path: DraemDaemon
+  register: dream_daemon
+
 - name: Get installed version of BYOND
   command: DreamDaemon -version
   register: installed_version
+  when: dream_daemon.stat.exists | bool
 
 - name: Determine whether BYOND needs to be updated
   set_fact:
-    update_byond: "{{ byond_version not in installed_version.stdout }}"
+    update_byond: "{{ not dream_daemon.stat.exists or byond_version not in installed_version.stdout }}"
 
 - name: Unarchive BYOND
   unarchive:


### PR DESCRIPTION
When I added the version-checking logic I forgot that this will fail fast when BYOND hasn't been installed yet, hah.

You can test both cases by doing: `molecule converge && molecule converge`
Just look at whether the unarchive/install tasks run (they should the first time and not the second time).

You can test fancy by actually setting a different BYOND version in variables, too, but I'm lazy.